### PR TITLE
Added missing cleanup function parameter

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -160,13 +160,13 @@ const writeDataToBottomOfTab = (tabName, data, clearTab) => {
 /**
  * Left aligns all cells in the spreadsheet and sorts by date
  */
-const cleanup = (sheetName) => {
+const cleanup = (sheetName, dateCol) => {
   var ss = SpreadsheetApp.getActiveSpreadsheet();
   var sheet = ss.getSheetByName(sheetName);
   sheet.getRange(1, 1, sheet.getMaxRows(), sheet.getMaxColumns()).activate();
   sheet.getActiveRangeList().setHorizontalAlignment("left");
-  console.log("bounds", transactionsDateColumnNumber + 1);
-  sheet.sort(transactionsDateColumnNumber + 1, false);
+  console.log("bounds", dateCol + 1);
+  sheet.sort(dateCol + 1, false);
   console.log(`${sheetName} has been cleaned up`);
 };
 


### PR DESCRIPTION
Found that the cleanup function was missing a parameter which caused it to sort the wrong column for the balances sheet if the date column was in a different location from the date column in the transactions sheet.