### PR TITLE
Remove posted pendings

### DIFF
--- a/config.js
+++ b/config.js
@@ -51,6 +51,7 @@ const transactionHeaders = [
   "Transaction Space",
   "Transaction Type",
   "Transaction ID",
+  "Pending Transaction ID",
   "Owner",
   "Account",
   "Mask",
@@ -87,6 +88,7 @@ const accountBalanceHeaders = [
 const developmentEndpoint = "https://development.plaid.com/transactions/get";
 const sandboxEndpoint = "https://sandbox.plaid.com/transactions/get";
 const transactionIdColumnNumber = transactionHeaders.indexOf("Transaction ID"); // Index values are zero indexed.
+const pendingTransactionIdColumnNumber = transactionHeaders.indexOf("Pending Transaction ID");
 const accountBalancesMaskColumnNumber = accountBalanceHeaders.indexOf("Mask");
 const accountBalancesDateColumnNumber = accountBalanceHeaders.indexOf("Date");
 const transactionsDateColumnNumber = transactionHeaders.indexOf("Date");

--- a/utils.js
+++ b/utils.js
@@ -160,13 +160,13 @@ const writeDataToBottomOfTab = (tabName, data, clearTab) => {
 /**
  * Left aligns all cells in the spreadsheet and sorts by date
  */
-const cleanup = (sheetName) => {
+const cleanup = (sheetName, dateCol) => {
   var ss = SpreadsheetApp.getActiveSpreadsheet();
   var sheet = ss.getSheetByName(sheetName);
   sheet.getRange(1, 1, sheet.getMaxRows(), sheet.getMaxColumns()).activate();
   sheet.getActiveRangeList().setHorizontalAlignment("left");
-  console.log("bounds", transactionsDateColumnNumber + 1);
-  sheet.sort(transactionsDateColumnNumber + 1, false);
+  console.log("bounds", dateCol + 1);
+  sheet.sort(dateCol + 1, false);
   console.log(`${sheetName} has been cleaned up`);
 };
 


### PR DESCRIPTION
This is an additional utility to remove pending transactions from the sheet that have already posted. This is if a user decides they want to bring in transactions as pending but then have an easy way to periodically clean them out.